### PR TITLE
[ARO-4527] Dynamically set Client ID and add extra MISE inbound policy

### DIFF
--- a/poc/pkg/templates/mise-configMap.yaml
+++ b/poc/pkg/templates/mise-configMap.yaml
@@ -15,18 +15,18 @@ data:
         "InboundPolicies": 
         [
           {
-            "Label": "{{ .Values.MISE.configMap.AzureAd.InboundPolicies.Label }}",
-            "AuthenticationSchemes": ["{{ .Values.MISE.configMap.AzureAd.InboundPolicies.AuthenticationSchemes }}"],
-            "TokenTypes": ["{{ .Values.MISE.configMap.AzureAd.InboundPolicies.TokenTypes }}"],
-            "Authority": "{{ .Values.MISE.configMap.AzureAd.InboundPolicies.Authority }}",
-            "ValidApplicationIds": ["{{ .Values.MISE.configMap.AzureAd.InboundPolicies.ValidApplicationIds }}"],
+            "Label": "{{ .Values.MISE.configMap.InboundPolicies.ArmPolicy.Label }}",
+            "AuthenticationSchemes": ["{{ .Values.MISE.configMap.InboundPolicies.ArmPolicy.AuthenticationSchemes }}"],
+            "TokenTypes": ["{{ .Values.MISE.configMap.InboundPolicies.ArmPolicy.TokenTypes }}"],
+            "Authority": "{{ .Values.MISE.configMap.InboundPolicies.ArmPolicy.Authority }}",
+            "ValidApplicationIds": ["{{ .Values.MISE.configMap.InboundPolicies.ArmPolicy.ValidApplicationIds }}"],
           },
           {
-            "Label": "{{ .Values.MISE.configMap.AzureAd.InboundPolicies.Internal.Label }}",
-            "AuthenticationSchemes": ["{{ .Values.MISE.configMap.AzureAd.InboundPolicies.Internal.AuthenticationSchemes }}"],
-            "TokenTypes": ["{{ .Values.MISE.configMap.AzureAd.InboundPolicies.Internal.TokenTypes }}"],
-            "Authority": "{{ .Values.MISE.configMap.AzureAd.InboundPolicies.Internal.Authority }}",
-            "ValidApplicationIds": ["{{ .Values.MISE.configMap.AzureAd.InboundPolicies.Internal.ValidApplicationIds }}"],
+            "Label": "{{ .Values.MISE.configMap.InboundPolicies.Internal.Label }}",
+            "AuthenticationSchemes": ["{{ .Values.MISE.configMap.InboundPolicies.Internal.AuthenticationSchemes }}"],
+            "TokenTypes": ["{{ .Values.MISE.configMap.InboundPolicies.Internal.TokenTypes }}"],
+            "Authority": "{{ .Values.MISE.configMap.InboundPolicies.Internal.Authority }}",
+            "ValidApplicationIds": ["{{ .Values.MISE.configMap.InboundPolicies.Internal.ValidApplicationIds }}"],
           }
         ],
       },

--- a/poc/pkg/templates/mise-configMap.yaml
+++ b/poc/pkg/templates/mise-configMap.yaml
@@ -15,18 +15,18 @@ data:
         "InboundPolicies": 
         [
           {
-            "Label": "{{ .Values.MISE.configMap.InboundPolicies.ArmPolicy.Label }}",
-            "AuthenticationSchemes": ["{{ .Values.MISE.configMap.InboundPolicies.ArmPolicy.AuthenticationSchemes }}"],
-            "TokenTypes": ["{{ .Values.MISE.configMap.InboundPolicies.ArmPolicy.TokenTypes }}"],
-            "Authority": "{{ .Values.MISE.configMap.InboundPolicies.ArmPolicy.Authority }}",
-            "ValidApplicationIds": ["{{ .Values.MISE.configMap.InboundPolicies.ArmPolicy.ValidApplicationIds }}"],
+            "Label": "{{ .Values.MISE.configMap.AzureAd.InboundPolicies.Arm.Label }}",
+            "AuthenticationSchemes": ["{{ .Values.MISE.configMap.AzureAd.InboundPolicies.Arm.AuthenticationSchemes }}"],
+            "TokenTypes": ["{{ .Values.MISE.configMap.AzureAd.InboundPolicies.Arm.TokenTypes }}"],
+            "Authority": "{{ .Values.MISE.configMap.AzureAd.InboundPolicies.Arm.Authority }}",
+            "ValidApplicationIds": ["{{ .Values.MISE.configMap.AzureAd.InboundPolicies.Arm.ValidApplicationIds }}"],
           },
           {
-            "Label": "{{ .Values.MISE.configMap.InboundPolicies.Internal.Label }}",
-            "AuthenticationSchemes": ["{{ .Values.MISE.configMap.InboundPolicies.Internal.AuthenticationSchemes }}"],
-            "TokenTypes": ["{{ .Values.MISE.configMap.InboundPolicies.Internal.TokenTypes }}"],
-            "Authority": "{{ .Values.MISE.configMap.InboundPolicies.Internal.Authority }}",
-            "ValidApplicationIds": ["{{ .Values.MISE.configMap.InboundPolicies.Internal.ValidApplicationIds }}"],
+            "Label": "{{ .Values.MISE.configMap.AzureAd.InboundPolicies.Internal.Label }}",
+            "AuthenticationSchemes": ["{{ .Values.MISE.configMap.AzureAd.InboundPolicies.Internal.AuthenticationSchemes }}"],
+            "TokenTypes": ["{{ .Values.MISE.configMap.AzureAd.InboundPolicies.Internal.TokenTypes }}"],
+            "Authority": "{{ .Values.MISE.configMap.AzureAd.InboundPolicies.Internal.Authority }}",
+            "ValidApplicationIds": ["{{ .Values.MISE.configMap.AzureAd.InboundPolicies.Internal.ValidApplicationIds }}"],
           }
         ],
       },

--- a/poc/pkg/templates/mise-configMap.yaml
+++ b/poc/pkg/templates/mise-configMap.yaml
@@ -20,6 +20,13 @@ data:
             "TokenTypes": ["{{ .Values.MISE.configMap.AzureAd.InboundPolicies.TokenTypes }}"],
             "Authority": "{{ .Values.MISE.configMap.AzureAd.InboundPolicies.Authority }}",
             "ValidApplicationIds": ["{{ .Values.MISE.configMap.AzureAd.InboundPolicies.ValidApplicationIds }}"],
+          },
+          {
+            "Label": "{{ .Values.MISE.configMap.AzureAd.InboundPolicies.Internal.Label }}",
+            "AuthenticationSchemes": ["{{ .Values.MISE.configMap.AzureAd.InboundPolicies.Internal.AuthenticationSchemes }}"],
+            "TokenTypes": ["{{ .Values.MISE.configMap.AzureAd.InboundPolicies.Internal.TokenTypes }}"],
+            "Authority": "{{ .Values.MISE.configMap.AzureAd.InboundPolicies.Internal.Authority }}",
+            "ValidApplicationIds": ["{{ .Values.MISE.configMap.AzureAd.InboundPolicies.Internal.ValidApplicationIds }}"],
           }
         ],
       },

--- a/poc/pkg/values.yaml
+++ b/poc/pkg/values.yaml
@@ -121,11 +121,12 @@ MISE:
       # Possible log levels: Trace, Debug, Information, Warning, Error, Critical, None 
       LogLevel: Debug
       InboundPolicies:
-        Label: aro-rp-arm-policy
-        AuthenticationSchemes: Bearer
-        TokenTypes: AppToken
-        Authority: https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/v2.0
-        ValidApplicationIds: ""
+        Arm:
+          Label: aro-rp-arm-policy
+          AuthenticationSchemes: Bearer
+          TokenTypes: AppToken
+          Authority: https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/v2.0
+          ValidApplicationIds: ""
         Internal:
           Label: aro-rp-internal-policy
           AuthenticationSchemes: Bearer

--- a/poc/pkg/values.yaml
+++ b/poc/pkg/values.yaml
@@ -116,18 +116,23 @@ MISE:
       # Use for telemetry headed to AAD on OpenID configuration requests.
       # https://identitydivision.visualstudio.com/DevEx/_wiki/wikis/DevEx.wiki/56/ServiceAuthLibrary-SAL-
       # TODO(jonachang) use ARO-RP first party principal when going to production
-      ClientId: a4c2469b-cf84-4145-8f5f-cb7bacf814bc
+      ClientId: ""
       TenantId: 72f988bf-86f1-41af-91ab-2d7cd011db47
       Audience: https://management.azure.com 
       # Possible log levels: Trace, Debug, Information, Warning, Error, Critical, None 
       LogLevel: Debug
       InboundPolicies:
-        Label: aro-rp-policy
+        Label: aro-rp-arm-policy
         AuthenticationSchemes: Bearer
         TokenTypes: AppToken
         Authority: https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/v2.0
-        # TODO(jonachang) use helm command to dynamically get the allowed client id
-        ValidApplicationIds: 704c7dfd-4ed1-4732-95c0-04a44b0895a0
+        ValidApplicationIds: ""
+        Internal:
+          Label: aro-rp-internal-policy
+          AuthenticationSchemes: Bearer
+          TokenTypes: AppToken
+          Authority: https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/v2.0
+          ValidApplicationIds: ""
     AllowedHosts: "*"
     Kestrel:
       Endpoints:

--- a/poc/pkg/values.yaml
+++ b/poc/pkg/values.yaml
@@ -115,7 +115,6 @@ MISE:
       Instance: https://login.microsoftonline.com
       # Use for telemetry headed to AAD on OpenID configuration requests.
       # https://identitydivision.visualstudio.com/DevEx/_wiki/wikis/DevEx.wiki/56/ServiceAuthLibrary-SAL-
-      # TODO(jonachang) use ARO-RP first party principal when going to production
       ClientId: ""
       TenantId: 72f988bf-86f1-41af-91ab-2d7cd011db47
       Audience: https://management.azure.com 

--- a/poc/pkg/values.yaml
+++ b/poc/pkg/values.yaml
@@ -121,12 +121,14 @@ MISE:
       # Possible log levels: Trace, Debug, Information, Warning, Error, Critical, None 
       LogLevel: Debug
       InboundPolicies:
+        # Policy for ARM
         Arm:
           Label: aro-rp-arm-policy
           AuthenticationSchemes: Bearer
           TokenTypes: AppToken
           Authority: https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/v2.0
           ValidApplicationIds: ""
+        # Policy for internal testing
         Internal:
           Label: aro-rp-internal-policy
           AuthenticationSchemes: Bearer


### PR DESCRIPTION
### Which issue this PR addresses:

Add extra MISE inbound policy for internal testing and allow client ID and allowed application ID to be set dynamically

### What this PR does / why we need it:

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:

<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?

<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->
